### PR TITLE
Correcting MaxCDN link

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                                     <th width="140"><a href="https://www.keycdn.com" rel="nofollow">KeyCDN</a></th>
                                     <th width="140"><a href="http://www.fastly.com" re="nofollow">Fastly</a></th>
                                     <th width="140"><a href="http://www.edgecast.com" rel="nofollow">EdgeCast</a></th>
-                                    <th width="140"><a href="http://net-dna.com" rel="nofollow">MaxCDN</a></th>
+                                    <th width="140"><a href="https://www.maxcdn.com" rel="nofollow">MaxCDN</a></th>
                                     <th width="140"><a href="http://cdnify.com" rel="nofollow">CDNify</a></th>
                                     <th width="140"><a href="http://cdn77.com" rel="nofollow">CDN77</a></th>
                                     <th width="140"><a href="http://www.cachefly.com" rel="nofollow">CacheFly</a></th>


### PR DESCRIPTION
The original URL was incorrect as it contained a hyphen. However, NetDNA is now MaxCDN so the correct link is simply `maxcdn.com`.
