### PR TITLE
keycdn custom rules update

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
                                     <th class="th-comp">Custom Rules</th>
                                     <td><i class="fa fa-check-circle-o partially"></i></td>
                                     <td><i class="fa fa-check-circle-o cost" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Premium only."></i></td>
-                                    <td><i class="fa fa-check-circle-o cost" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Minimum 10TB/month."></i></td>
+                                    <td><i class="fa fa-check-circle-o cost" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Minimum 10TB/month or buy 400$ in credits."></i></td>
                                     <td><i class="fa fa-check-circle-o partially" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Disabled by default."></i></td>
                                     <td><i class="fa fa-check-circle-o cost"></i></td>
                                     <td><i class="fa fa-check-circle-o cost"></i></td>


### PR DESCRIPTION
Recenty I wrote them to have custom error pages and they told me:

> In some certain cases we can add custom error pages to push zones, but it requires custom rules. 
> Custom rules can be added for $400. The $400 can then be used for traffic delivery. 
