### PR TITLE
Update CloudFront pricing and HTTP/2 support

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
             <div class="col-md-6">
                 <section class="widget">
                     <header>
-                        <h4>Last update &nbsp;<span class="label label-default fw-normal">March 1, 2016</span></h4>
+                        <h4>Last update &nbsp;<span class="label label-default fw-normal">December 10, 2016</span></h4>
                     </header>
                     <div class="widget-body">
                         <h5><i class="fa fa-circle-o"></i> What is this CDN comparison about?</h5>
@@ -87,7 +87,7 @@
                                     <th width="140"><a href="http://aws.amazon.com/cloudfront" rel="nofollow">CloudFront</a></th>
                                     <th width="140"><a href="http://azure.microsoft.com/en-us/services/cdn" rel="nofollow">Azure CDN</a></th>
                                     <th width="140"><a href="https://www.keycdn.com" rel="nofollow">KeyCDN</a></th>
-                                    <th width="140"><a href="http://www.fastly.com" re="nofollow">Fastly</a></th>
+                                    <th width="140"><a href="http://www.fastly.com" rel="nofollow">Fastly</a></th>
                                     <th width="140"><a href="http://www.edgecast.com" rel="nofollow">EdgeCast</a></th>
                                     <th width="140"><a href="http://net-dna.com" rel="nofollow">MaxCDN</a></th>
                                     <th width="140"><a href="http://cdnify.com" rel="nofollow">CDNify</a></th>
@@ -158,7 +158,12 @@
                                 </tr>
                                 <tr>
                                     <th class="th-comp">Bandwith Pricing</th>
-                                    <td><small><span class="fw-semi-bold">$0.12/GB</span></small></td>
+                                    <td>
+                                        <small>
+                                            <p class="fw-semi-bold">$0.085/GB</p>
+                                            <span class="text-semi-muted">Region-dependent</span>
+                                        </small>
+                                    </td>
                                     <td><small><span class="fw-semi-bold">$0.09/GB</span></small></td>
                                     <td><small><span class="fw-semi-bold">$0.04/GB</span></small></td>
                                     <td>
@@ -325,7 +330,7 @@
                                 </tr>
                                 <tr>
                                     <th class="th-comp">HTTP/2</th>
-                                    <td><i class="fa fa-times-circle nope"></i></td>
+                                    <td><i class="fa fa-check-circle-o fully"></i></td>
                                     <td><i class="fa fa-times-circle nope"></i></td>
                                     <td><i class="fa fa-check-circle-o fully"></i></td>
                                     <td><i class="fa fa-times-circle nope"></i></td>


### PR DESCRIPTION
Fix a rel attribute
Update last updated

## Relevant links
* [CloudFront HTTP/2 Support](https://aws.amazon.com/about-aws/whats-new/2016/09/amazon-cloudfront-now-supports-http2/)
* [CloudFront Pricing](https://aws.amazon.com/cloudfront/pricing/)