### PR TITLE
update cloudfront values

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@
                                 </tr>
                                 <tr>
                                     <th class="th-comp">IPv6</th>
-                                    <td><i class="fa fa-question-circle unknown"></i></td>
+                                    <td><i class="fa fa-check-circle-o fully"></i></td>
                                     <td><i class="fa fa-question-circle unknown"></i></td>
                                     <td><i class="fa fa-question-circle unknown"></i></td>
                                     <td><i class="fa fa-question-circle unknown"></i></td>
@@ -469,7 +469,7 @@
                                 </tr>
                                 <tr>
                                     <th class="th-comp">Custom SSL</th>
-                                    <td><i class="fa fa-check-circle-o cost"></i></td>
+                                    <td><i class="fa fa-check-circle-o fully" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Based on SNI."></i></td>
                                     <td><i class="fa fa-times-circle nope"></i></td>
                                     <td><i class="fa fa-check-circle-o fully" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Based on SNI."></i></td>
                                     <td><i class="fa fa-check-circle-o cost"></i></td>
@@ -481,7 +481,7 @@
                                 </tr>
                                 <tr>
                                     <th class="th-comp">Wildcard SSL</th>
-                                    <td><i class="fa fa-check-circle-o cost"></i></td>
+                                    <td><i class="fa fa-check-circle-o fully" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Based on SNI."></i></td>
                                     <td><i class="fa fa-times-circle nope"></i></td>
                                     <td><i class="fa fa-check-circle-o fully" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Based on SNI."></i></td>
                                     <td><i class="fa fa-check-circle-o cost"></i></td>
@@ -493,7 +493,7 @@
                                 </tr>
                                 <tr>
                                     <th class="th-comp">Let's Encrypt Integration</th>
-                                    <td><i class="fa fa-times-circle nope"></i></td>
+                                    <td><i class="fa fa-times-circle nope"  data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="comparable to LetsEncrypt, AWS offers easy, free, auto-renewing SSLs thru Certificate Manager."></i></td>
                                     <td><i class="fa fa-times-circle nope"></i></td>
                                     <td><i class="fa fa-check-circle-o fully"></i></td>
                                     <td><i class="fa fa-times-circle nope"></i></td>


### PR DESCRIPTION
ipv6 support - https://aws.amazon.com/about-aws/whats-new/2016/10/ipv6-support-for-cloudfront-waf-and-s3-transfer-acceleration/
custom SSL - SNI custom SSLs are free, https://aws.amazon.com/cloudfront/custom-ssl-domains/
wildcard SSL - cloudfront can use amazon certificate manager wildcard SSLs, which are free https://aws.amazon.com/certificate-manager/pricing/
letsencrypt - AWS Certificate Manager fills a similar role as LetsEncrypt, offering free, click-thru install SSLs, with auto-renewal